### PR TITLE
Added default null handling for type converters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
           channel: stable
 
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
           channel: stable
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -196,14 +196,14 @@ packages:
       path: "../flat_generator"
       relative: true
     source: path
-    version: "1.6.0+1"
+    version: "1.6.1+1"
   flat_orm:
     dependency: "direct main"
     description:
       path: "../flat_orm"
       relative: true
     source: path
-    version: "1.5.0+1"
+    version: "1.5.1+1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/flat_generator/lib/misc/extension/type_converters_extension.dart
+++ b/flat_generator/lib/misc/extension/type_converters_extension.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
+import 'package:flat_generator/misc/extension/dart_type_extension.dart';
 import 'package:flat_generator/misc/extension/iterable_extension.dart';
 import 'package:flat_generator/value_object/type_converter.dart';
 import 'package:source_gen/source_gen.dart';
@@ -13,11 +14,12 @@ extension TypeConvertersExtension on Iterable<TypeConverter> {
 
   /// Returns the [TypeConverter] in the closest [TypeConverterScope] for
   /// [dartType] or null
-  TypeConverter? getClosestOrNull(DartType dartType) {
-    return sortedByDescending((typeConverter) => typeConverter.scope.index)
-        .firstWhereOrNull(
-            (typeConverter) => typeConverter.fieldType == dartType);
-  }
+  TypeConverter? getClosestOrNull(DartType dartType) => toList()
+      .reversed
+      .sortedByDescending((e) => e.scope.index)
+      .firstWhereOrNull((e) =>
+          TypeChecker.fromStatic(e.fieldType).isExactlyType(dartType) &&
+          (dartType.isNullable || !e.fieldType.isNullable));
 
   /// Returns the [TypeConverter] in the closest [TypeConverterScope] for
   /// [dartType]

--- a/flat_generator/lib/processor/field_processor.dart
+++ b/flat_generator/lib/processor/field_processor.dart
@@ -30,7 +30,9 @@ class FieldProcessor extends Processor<Field> {
     final columnName = _prefix + _getColumnName(name);
     final isNullable = _fieldElement.type.isNullable;
     final typeConverter = {
-      ..._fieldElement.getTypeConverters(TypeConverterScope.field),
+      _fieldElement
+          .getTypeConverters(TypeConverterScope.field)
+          .getClosestOrNull(_fieldElement.type),
       _typeConverter
     }.whereNotNull().closestOrNull;
 

--- a/flat_generator/lib/processor/queryable_processor.dart
+++ b/flat_generator/lib/processor/queryable_processor.dart
@@ -98,17 +98,22 @@ abstract class QueryableProcessor<T extends Queryable> extends Processor<T> {
             parameterElement,
           );
         } else {
-          final typeConverter = [
-            ...queryableTypeConverters,
-            field.typeConverter
-          ].whereNotNull().getClosest(parameterElement.type);
+          final typeConverter = field.typeConverter!;
           final castedDatabaseValue = databaseValue.cast(
             typeConverter.databaseType,
             parameterElement,
           );
 
-          parameterValue =
-              '_${typeConverter.name.decapitalize()}.decode($castedDatabaseValue)';
+          final shouldCheckForNullability =
+              !typeConverter.fieldType.isNullable &&
+                  parameterElement.type.isNullable;
+          if (shouldCheckForNullability) {
+            parameterValue =
+                '$databaseValue == null ? null : _${typeConverter.name.decapitalize()}.decode($castedDatabaseValue)';
+          } else {
+            parameterValue =
+                '_${typeConverter.name.decapitalize()}.decode($castedDatabaseValue)';
+          }
         }
       } else {
         final embedded = field as Embedded;

--- a/flat_generator/test/misc/extension/type_converters_extension_test.dart
+++ b/flat_generator/test/misc/extension/type_converters_extension_test.dart
@@ -36,23 +36,68 @@ void main() {
 
   group('getClosestOrNull', () {
     test('returns closest type converter for DartType', () async {
-      final databaseTypeConverter = TypeConverter(
-        'database type converter',
+      final typeConverter1 = TypeConverter(
+        'database type converter1',
         await dateTimeDartType,
         await intDartType,
         TypeConverterScope.database,
       );
-      final daoMethodTypeConverter = TypeConverter(
-        'DAO method type converter',
-        await dateTimeDartType,
+      final typeConverter2 = TypeConverter(
+        'database type converter2',
+        await getDartTypeFromDeclaration('final num b;'),
+        await intDartType,
+        TypeConverterScope.database,
+      );
+      final typeConverter3 = TypeConverter(
+        'DAO method type converter1',
+        await getDartTypeFromDeclaration('final num b;'),
         await intDartType,
         TypeConverterScope.daoMethod,
       );
-      final typeConverters = [databaseTypeConverter, daoMethodTypeConverter];
+      final typeConverter4 = TypeConverter(
+        'DAO method type converter2',
+        await getDartTypeFromDeclaration('final num? b;'),
+        await intDartType,
+        TypeConverterScope.daoMethod,
+      );
+      final typeConverter5 = TypeConverter(
+        'DAO method type converter3',
+        await getDartTypeFromDeclaration('final int? b;'),
+        await intDartType,
+        TypeConverterScope.daoMethod,
+      );
+      final typeConverters = [
+        typeConverter1,
+        typeConverter2,
+        typeConverter3,
+        typeConverter4,
+        typeConverter5,
+      ];
 
-      final actual = typeConverters.getClosestOrNull(await dateTimeDartType);
+      var dartType = await getDartTypeFromDeclaration('final num b;');
+      var actual = typeConverters.getClosestOrNull(dartType);
 
-      expect(actual, equals(daoMethodTypeConverter));
+      expect(actual, typeConverter3);
+
+      dartType = await getDartTypeFromDeclaration('final int? b;');
+      actual = typeConverters.getClosestOrNull(dartType);
+
+      expect(actual, typeConverter5);
+
+      dartType = await getDartTypeFromDeclaration('final int b;');
+      actual = typeConverters.getClosestOrNull(dartType);
+
+      expect(actual, null);
+
+      dartType = await getDartTypeFromDeclaration('final num? b;');
+      actual = typeConverters.getClosestOrNull(dartType);
+
+      expect(actual, typeConverter4);
+
+      dartType = await getDartTypeFromDeclaration('final DateTime? b;');
+      actual = typeConverters.getClosestOrNull(dartType);
+
+      expect(actual, typeConverter1);
     });
 
     test('returns null when not type converter for DartType found', () async {

--- a/flat_generator/test/processor/queryable_processor_test.dart
+++ b/flat_generator/test/processor/queryable_processor_test.dart
@@ -154,12 +154,6 @@ void main() {
 
     test('process queryable and prefer local type converter over external',
         () async {
-      final externalTypeConverter = TypeConverter(
-        'ExternalConverter',
-        await dateTimeDartType,
-        await intDartType,
-        TypeConverterScope.database,
-      );
       final classElement = await createClassElement('''
       @TypeConverters([DateTimeConverter])
       class Order {
@@ -205,8 +199,7 @@ void main() {
       }
     ''');
 
-      final actual =
-          TestProcessor(classElement, {externalTypeConverter}).process();
+      final actual = TestProcessor(classElement).process();
 
       final typeConverter = TypeConverter(
         'DateTimeConverter',
@@ -237,6 +230,51 @@ void main() {
         constructor,
       );
       expect(actual, equals(expected));
+    });
+
+    test('prefer the closest suitable type converter', () async {
+      final classElement = await createClassElement('''
+      @TypeConverters([DateTimeConverter, NullableDateTimeConverter])
+      class Product {
+        final DateTime date1;
+        
+        @TypeConverters([NullableDateTimeConverter, DateTimeConverter])
+        final DateTime? date2;
+        
+        @TypeConverters([DateTimeConverter, NullableDateTimeConverter])
+        final DateTime? date3;
+        
+        Product(this.date1, this.date2, this.date3);
+      }
+      
+      class DateTimeConverter extends TypeConverter<DateTime, int> {
+        @override
+        DateTime decode(int databaseValue) {
+          return DateTime.now();
+        }
+
+        @override
+        int encode(DateTime value) {
+          return 0;
+        }
+      }
+      
+      class NullableDateTimeConverter extends TypeConverter<DateTime?, int?> {
+        @override
+        DateTime? decode(int databaseValue) {
+          return DateTime.now();
+        }
+
+        @override
+        int? encode(DateTime? value) {
+          return 0;
+        }
+      }
+    ''');
+      final actual = TestProcessor(classElement).process();
+      const constructor =
+          "Product(_dateTimeConverter.decode(row['date1'] as int), row['date2'] == null ? null : _dateTimeConverter.decode(row['date2'] as int), _nullableDateTimeConverter.decode(row['date3'] as int?))";
+      expect(actual.constructor, constructor);
     });
   });
 


### PR DESCRIPTION
With this change, there is no need to register nullable type converter for nullable type converters unless you need to return something else instead of just returning `null` for `null` values. The closest suitable type converter will be used. (Fixes #12 )

**Example 1**: With `@TypeConverters([DateTimeConverter])`, `DateTimeConverter` will be used for both `DateTime` and `DateTime?`.

**Example 2**: With `@TypeConverters([DateTimeConverter, NullableDateTimeConverter])`, `DateTimeConverter` will be used for `DateTime` and `NullableDateTimeConverter` for `DateTime?`.

**Example 3**: With `@TypeConverters([NullableDateTimeConverter, DateTimeConverter])`, `DateTimeConverter` will be used for both `DateTime` and `DateTime?`.

```dart
class DateTimeConverter extends TypeConverter<DateTime, int> {
  @override
  DateTime decode(int databaseValue) {
    return DateTime.now();
  }
  @override
  int encode(DateTime value) {
    return 0;
  }
}
class NullableDateTimeConverter extends TypeConverter<DateTime?, int> {
  @override
  DateTime? decode(int databaseValue) {
    return DateTime.now();
  }
  @override
  int encode(DateTime? value) {
    return 0;
  }
}
```